### PR TITLE
keymap subscriptions to use onDid event names

### DIFF
--- a/lib/keybinding-resolver-view.coffee
+++ b/lib/keybinding-resolver-view.coffee
@@ -31,13 +31,13 @@ class KeyBindingResolverView extends View
 
   attach: ->
     atom.workspaceView.prependToBottom(this)
-    @subscribe atom.keymap, "matched", ({keystrokes, binding, keyboardEventTarget}) =>
+    @subscribe atom.keymap.onDidMatchBinding ({keystrokes, binding, keyboardEventTarget}) =>
       @update(keystrokes, binding, keyboardEventTarget)
 
-    @subscribe atom.keymap, "matched-partially", ({keystrokes, partiallyMatchedBindings, keyboardEventTarget}) =>
+    @subscribe atom.keymap.onDidPartiallyMatchBindings ({keystrokes, partiallyMatchedBindings, keyboardEventTarget}) =>
       @updatePartial(keystrokes, partiallyMatchedBindings)
 
-    @subscribe atom.keymap, "match-failed", ({keystrokes, keyboardEventTarget}) =>
+    @subscribe atom.keymap.onDidFailToMatchBinding ({keystrokes, keyboardEventTarget}) =>
       @update(keystrokes, null, keyboardEventTarget)
 
   detach: ->


### PR DESCRIPTION
Thought I start this change, since the specs already warn about these being deprecated.
