### PR TITLE
Remove panel classes

### DIFF
--- a/lib/keybinding-resolver-view.coffee
+++ b/lib/keybinding-resolver-view.coffee
@@ -4,7 +4,7 @@
 module.exports =
 class KeyBindingResolverView extends View
   @content: ->
-    @div class: 'key-binding-resolver tool-panel pannel panel-bottom padding', =>
+    @div class: 'key-binding-resolver', =>
       @div class: 'panel-heading padded', =>
         @span 'Key Binding Resolver: '
         @span outlet: 'keystroke', 'Press any key'


### PR DESCRIPTION
These were giving the resolver panel a double border due to `tool-panel` and `panel-bottom` also being on the containing `atom-panel` element. I also removed the misspelled `pannel` and `padding` classes which don't do anything.
