### PR TITLE
Show keyup events that match a binding

### DIFF
--- a/lib/keybinding-resolver-view.coffee
+++ b/lib/keybinding-resolver-view.coffee
@@ -34,19 +34,21 @@ class KeyBindingResolverView extends View
       @panel.destroy()
       @panel = null
 
-    @disposables.add atom.keymaps.onDidMatchBinding ({keystrokes, binding, keyboardEventTarget}) =>
-      @update(keystrokes, binding, keyboardEventTarget)
+    @disposables.add atom.keymaps.onDidMatchBinding ({keystrokes, binding, keyboardEventTarget, eventType}) =>
+      @update(keystrokes, binding, keyboardEventTarget, eventType)
 
-    @disposables.add atom.keymaps.onDidPartiallyMatchBindings ({keystrokes, partiallyMatchedBindings, keyboardEventTarget}) =>
+    @disposables.add atom.keymaps.onDidPartiallyMatchBindings ({keystrokes, partiallyMatchedBindings, keyboardEventTarget, eventType}) =>
       @updatePartial(keystrokes, partiallyMatchedBindings)
 
-    @disposables.add atom.keymaps.onDidFailToMatchBinding ({keystrokes, keyboardEventTarget}) =>
-      @update(keystrokes, null, keyboardEventTarget)
+    @disposables.add atom.keymaps.onDidFailToMatchBinding ({keystrokes, keyboardEventTarget, eventType}) =>
+      @update(keystrokes, null, keyboardEventTarget, eventType)
 
   detach: ->
     @disposables?.dispose()
 
-  update: (keystrokes, keyBinding, keyboardEventTarget) ->
+  update: (keystrokes, keyBinding, keyboardEventTarget, eventType) ->
+    return if eventType is 'keyup' and keyBinding is null
+
     @keystroke.html $$ ->
       @span class: 'keystroke', keystrokes
 

--- a/spec/keybinding-resolver-view-spec.coffee
+++ b/spec/keybinding-resolver-view-spec.coffee
@@ -35,12 +35,13 @@ describe "KeyBindingResolverView", ->
       expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 1
       expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 1
 
-      # It should not render the keyup event data because there is no match
-      document.dispatchEvent atom.keymaps.constructor.buildKeyupEvent('x', target: workspaceElement)
-      expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x'
-      expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
-      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 1
-      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 1
+      if atom.keymaps.constructor.buildKeyupEvent?
+        # It should not render the keyup event data because there is no match
+        document.dispatchEvent atom.keymaps.constructor.buildKeyupEvent('x', target: workspaceElement)
+        expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x'
+        expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
+        expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 1
+        expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 1
 
     it "displays all commands for the keydown event but does not clear for the keyup when there is no keyup binding", ->
       atom.keymaps.add 'name', '.workspace': 'x': 'match-1'
@@ -54,9 +55,10 @@ describe "KeyBindingResolverView", ->
       expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 1
       expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 0
 
-      # It should not render the keyup event data because there is no match
-      document.dispatchEvent atom.keymaps.constructor.buildKeyupEvent('x', target: workspaceElement)
-      expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x ^x'
-      expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
-      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 0
-      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 0
+      if atom.keymaps.constructor.buildKeyupEvent?
+        # It should not render the keyup event data because there is no match
+        document.dispatchEvent atom.keymaps.constructor.buildKeyupEvent('x', target: workspaceElement)
+        expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x ^x'
+        expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
+        expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 0
+        expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 0

--- a/spec/keybinding-resolver-view-spec.coffee
+++ b/spec/keybinding-resolver-view-spec.coffee
@@ -23,13 +23,40 @@ describe "KeyBindingResolverView", ->
       expect(workspaceElement.querySelector('.key-binding-resolver')).toExist()
 
   describe "when a keydown event occurs", ->
-    it "displays all commands for the event", ->
+    it "displays all commands for the keydown event but does not clear for the keyup when there is no keyup binding", ->
       atom.keymaps.add 'name', '.workspace': 'x': 'match-1'
       atom.keymaps.add 'name', '.workspace': 'x': 'match-2'
       atom.keymaps.add 'name', '.never-again': 'x': 'unmatch-2'
 
       atom.commands.dispatch workspaceElement, 'key-binding-resolver:toggle'
       document.dispatchEvent atom.keymaps.constructor.buildKeydownEvent('x', target: workspaceElement)
+      expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x'
       expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
       expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 1
       expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 1
+
+      # It should not render the keyup event data because there is no match
+      document.dispatchEvent atom.keymaps.constructor.buildKeyupEvent('x', target: workspaceElement)
+      expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x'
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 1
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 1
+
+    it "displays all commands for the keydown event but does not clear for the keyup when there is no keyup binding", ->
+      atom.keymaps.add 'name', '.workspace': 'x': 'match-1'
+      atom.keymaps.add 'name', '.workspace': 'x ^x': 'match-2'
+      atom.keymaps.add 'name', '.never-again': 'x': 'unmatch-2'
+
+      atom.commands.dispatch workspaceElement, 'key-binding-resolver:toggle'
+      document.dispatchEvent atom.keymaps.constructor.buildKeydownEvent('x', target: workspaceElement)
+      expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x (partial)'
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 0
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 1
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 0
+
+      # It should not render the keyup event data because there is no match
+      document.dispatchEvent atom.keymaps.constructor.buildKeyupEvent('x', target: workspaceElement)
+      expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x ^x'
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 0
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 0


### PR DESCRIPTION
This depends on https://github.com/atom/atom-keymap/pull/113 making it into core. 

It will show keyup events, but only those that match a binding. Otherwise most events that people care about will be masked by the keyup events.