### PR TITLE
Make etch perform updates synchronously in specs

### DIFF
--- a/spec/keybinding-resolver-view-spec.coffee
+++ b/spec/keybinding-resolver-view-spec.coffee
@@ -1,7 +1,13 @@
 etch = require 'etch'
 
+etch.setScheduler({
+  updateDocument: (callback) -> callback()
+  getNextUpdatePromise: -> Promise.resolve()
+})
+
 describe "KeyBindingResolverView", ->
   workspaceElement = null
+
   beforeEach ->
     workspaceElement = atom.views.getView(atom.workspace)
 

--- a/spec/keybinding-resolver-view-spec.coffee
+++ b/spec/keybinding-resolver-view-spec.coffee
@@ -34,24 +34,19 @@ describe "KeyBindingResolverView", ->
       atom.keymaps.add 'name', '.never-again': 'x': 'unmatch-2'
 
       atom.commands.dispatch workspaceElement, 'key-binding-resolver:toggle'
+
       document.dispatchEvent atom.keymaps.constructor.buildKeydownEvent('x', target: workspaceElement)
+      expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x'
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 1
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 1
 
-      waitsForPromise ->
-        etch.getScheduler().getNextUpdatePromise()
-
-      runs ->
-        expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x'
-        expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
-        expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 1
-        expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 1
-
-        if atom.keymaps.constructor.buildKeyupEvent?
-          # It should not render the keyup event data because there is no match
-          document.dispatchEvent atom.keymaps.constructor.buildKeyupEvent('x', target: workspaceElement)
-          expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x'
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 1
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 1
+      # It should not render the keyup event data because there is no match
+      document.dispatchEvent atom.keymaps.constructor.buildKeyupEvent('x', target: workspaceElement)
+      expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x'
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 1
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 1
 
     it "displays all commands for the keydown event but does not clear for the keyup when there is no keyup binding", ->
       atom.keymaps.add 'name', '.workspace': 'x': 'match-1'
@@ -61,46 +56,28 @@ describe "KeyBindingResolverView", ->
 
       atom.commands.dispatch workspaceElement, 'key-binding-resolver:toggle'
 
-      # TODO: remove this conditional when keyup change to keymap is in beta
-      if atom.keymaps.constructor.buildKeyupEvent?
-        # Not partial because it dispatches the command for `x` immediately due to only having keyup events in remainder of partial match
-        document.dispatchEvent atom.keymaps.constructor.buildKeydownEvent('x', target: workspaceElement)
-        waitsForPromise ->
-          etch.getScheduler().getNextUpdatePromise()
+      # Not partial because it dispatches the command for `x` immediately due to only having keyup events in remainder of partial match
+      document.dispatchEvent atom.keymaps.constructor.buildKeydownEvent('x', target: workspaceElement)
+      expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x'
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 0
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 1
 
-        runs ->
-          expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x'
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 0
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 1
-          # It should not render the keyup event data because there is no match
-          document.dispatchEvent atom.keymaps.constructor.buildKeyupEvent('x', target: workspaceElement)
+      # It should not render the keyup event data because there is no match
+      document.dispatchEvent atom.keymaps.constructor.buildKeyupEvent('x', target: workspaceElement)
+      expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x ^x'
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 0
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 0
 
-        waitsForPromise ->
-          etch.getScheduler().getNextUpdatePromise()
+      document.dispatchEvent atom.keymaps.constructor.buildKeydownEvent('a', target: workspaceElement)
+      expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'a (partial)'
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 0
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 1
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 0
 
-        runs ->
-          expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'x ^x'
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 0
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 0
-          document.dispatchEvent atom.keymaps.constructor.buildKeydownEvent('a', target: workspaceElement)
-
-        waitsForPromise ->
-          etch.getScheduler().getNextUpdatePromise()
-
-        runs ->
-          expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'a (partial)'
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 0
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 1
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 0
-          document.dispatchEvent atom.keymaps.constructor.buildKeyupEvent('a', target: workspaceElement)
-
-        waitsForPromise ->
-          etch.getScheduler().getNextUpdatePromise()
-
-        runs ->
-          expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'a ^a'
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 0
-          expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 0
+      document.dispatchEvent atom.keymaps.constructor.buildKeyupEvent('a', target: workspaceElement)
+      expect(workspaceElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe 'a ^a'
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .used')).toHaveLength 1
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unused')).toHaveLength 0
+      expect(workspaceElement.querySelectorAll('.key-binding-resolver .unmatched')).toHaveLength 0


### PR DESCRIPTION
[Whitespace-insensitive diff](https://github.com/atom/keybinding-resolver/pull/48/files?w=1)

We're seeing this package's tests fail intermittently in Atom's main Circle CI build.

https://circleci.com/gh/atom/atom/2664

```
KeyBindingResolverView
  when a keydown event occurs
    it displays all commands for the keydown event but does not clear for the keyup when there is no keyup binding
      timeout: timed out after 60000 msec waiting for promise to be resolved or rejected
    it displays all commands for the keydown event but does not clear for the keyup when there is no keyup binding
      timeout: timed out after 60000 msec waiting for promise to be resolved or rejected
```

I think it's because of a race condition between etch's DOM updates and jasmine's asynchronous queue execution.

Because there's no complex logic around the timing of DOM updates in this package, I think it's ok to simply use synchronous DOM updates in the tests and :fire: all of the `waitsFor` and `runs`.

/cc @as-cii @nathansobo 

This does seem like a usability issue with etch. Why is waiting for `etch.getScheduler().getNextUpdatePromise()` not sufficient to guarantee that the DOM has updated in this case?