### PR TITLE
Allow opening keymaps starting with `core/`

### DIFF
--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -185,6 +185,8 @@ export default class KeyBindingResolverView {
   openKeybindingFile (keymapPath) {
     if (this.isInAsarArchive(keymapPath)) {
       keymapPath = this.extractBundledKeymap(keymapPath)
+    } else if (keymapPath.startsWith('core/')) {
+      keymapPath = this.extractBundledKeymap(keymapPath.replace('core/', ''))
     }
 
     atom.workspace.open(keymapPath)


### PR DESCRIPTION
This will be used in https://github.com/atom/atom/pull/14024 where keymaps are loaded during snapshot. Since we are unable to supply an absolute path when that code runs, we will instead use `core/` in order to allow this package to understand if it needs to extract a bundled keymap from Atom's package.json.