### PR TITLE
Support reading snapshotted keymaps

### DIFF
--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -182,9 +182,24 @@ export default class KeyBindingResolverView {
     return extractedKeymapPath
   }
 
+  extractBundledPackageKeymap (keymapRelativePath) {
+    const packageName = keymapRelativePath.split('/')[1]
+    const keymapName = path.basename(keymapRelativePath)
+    const metadata = atom.packages.packagesCache[packageName] || {}
+    const keymaps = metadata.keymaps || {}
+    const extractedKeymapPath = path.join(require('temp').mkdirSync('atom-bundled-keymap-'), keymapName)
+    fs.writeFileSync(
+      extractedKeymapPath,
+      JSON.stringify(keymaps[keymapRelativePath] || {}, null, 2)
+    )
+    return extractedKeymapPath
+  }
+
   openKeybindingFile (keymapPath) {
     if (this.isInAsarArchive(keymapPath)) {
       keymapPath = this.extractBundledKeymap(keymapPath)
+    } else if (keymapPath.startsWith('core/node_modules')) {
+      keymapPath = this.extractBundledPackageKeymap(keymapPath.replace('core/', ''))
     } else if (keymapPath.startsWith('core/')) {
       keymapPath = this.extractBundledKeymap(keymapPath.replace('core/', ''))
     }

--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -183,7 +183,7 @@ export default class KeyBindingResolverView {
   }
 
   extractBundledPackageKeymap (keymapRelativePath) {
-    const packageName = keymapRelativePath.split('/')[1]
+    const packageName = keymapRelativePath.split(path.sep)[1]
     const keymapName = path.basename(keymapRelativePath)
     const metadata = atom.packages.packagesCache[packageName] || {}
     const keymaps = metadata.keymaps || {}

--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -198,10 +198,10 @@ export default class KeyBindingResolverView {
   openKeybindingFile (keymapPath) {
     if (this.isInAsarArchive(keymapPath)) {
       keymapPath = this.extractBundledKeymap(keymapPath)
-    } else if (keymapPath.startsWith('core/node_modules')) {
-      keymapPath = this.extractBundledPackageKeymap(keymapPath.replace('core/', ''))
-    } else if (keymapPath.startsWith('core/')) {
-      keymapPath = this.extractBundledKeymap(keymapPath.replace('core/', ''))
+    } else if (keymapPath.startsWith('core:node_modules')) {
+      keymapPath = this.extractBundledPackageKeymap(keymapPath.replace('core:', ''))
+    } else if (keymapPath.startsWith('core:')) {
+      keymapPath = this.extractBundledKeymap(keymapPath.replace('core:', ''))
     }
 
     atom.workspace.open(keymapPath)


### PR DESCRIPTION
This pull request will allow users to read keymaps when they were added inside the snapshot. This is part of an ongoing pull request where bundled packages are preloaded to speed up startup time. 

Since we don't have access to the absolute path of the keymap file during the snapshot phase, we add keymaps and other settings as `core:node_modules/{packageName}/{resource}`. Similarly to what we did on #51, with these changes `keybinding-resolver` will be able to interpret the leading `core:node_modules` string and load the keymap from the bundled packages metadata that ships with Atom.