### PR TITLE
Visualize aborted keybindings

### DIFF
--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -13,6 +13,7 @@ export default class KeyBindingResolverView {
     this.unusedKeyBindings = []
     this.unmatchedKeyBindings = []
     this.partiallyMatchedBindings = []
+    this.abortedBindings = []
     etch.initialize(this)
   }
 
@@ -41,7 +42,7 @@ export default class KeyBindingResolverView {
       this.panel = null
     }))
 
-    this.disposables.add(atom.keymaps.onDidMatchBinding(({keystrokes, binding, keyboardEventTarget, eventType}) => {
+    this.disposables.add(atom.keymaps.onDidMatchBinding(({keystrokes, binding, keyboardEventTarget, eventType, abortedBindings}) => {
       if (eventType === 'keyup' && binding == null) {
         return
       }
@@ -49,12 +50,13 @@ export default class KeyBindingResolverView {
       const unusedKeyBindings = atom.keymaps
         .findKeyBindings({keystrokes, target: keyboardEventTarget})
         .filter((b) => b !== binding)
+        .filter((b) => !abortedBindings.includes(b))
 
       const unmatchedKeyBindings = atom.keymaps
         .findKeyBindings({keystrokes})
-        .filter((b) => b !== binding && !unusedKeyBindings.includes(b))
+        .filter((b) => b !== binding && !unusedKeyBindings.includes(b) && !abortedBindings.includes(b))
 
-      this.update({usedKeyBinding: binding, unusedKeyBindings, unmatchedKeyBindings, keystrokes})
+      this.update({usedKeyBinding: binding, unusedKeyBindings, unmatchedKeyBindings, keystrokes, abortedBindings})
     }))
 
     this.disposables.add(atom.keymaps.onDidPartiallyMatchBindings(({keystrokes, partiallyMatchedBindings}) => {
@@ -87,6 +89,7 @@ export default class KeyBindingResolverView {
     this.unusedKeyBindings = props.unusedKeyBindings || []
     this.unmatchedKeyBindings = props.unmatchedKeyBindings || []
     this.partiallyMatchedBindings = props.partiallyMatchedBindings || []
+    this.abortedBindings = props.abortedBindings || []
     return etch.update(this)
   }
 
@@ -145,6 +148,13 @@ export default class KeyBindingResolverView {
         <table className='table-condensed'>
           <tbody>
           {usedKeyBinding}
+          {this.abortedBindings.map((binding) => (
+            <tr className='aborted'>
+              <td className='command'>{binding.command}</td>
+              <td className='selector'>{binding.selector}</td>
+              <td className='source' onclick={() => this.openKeybindingFile(binding.source)}>{binding.source}</td>
+            </tr>
+          ))}
           {this.unusedKeyBindings.map((binding) => (
             <tr className='unused'>
               <td className='command'>{binding.command}</td>

--- a/styles/keybinding-resolver.less
+++ b/styles/keybinding-resolver.less
@@ -14,6 +14,10 @@
       color: @text-color-success;
     }
 
+    .aborted {
+      color: @text-color-warning;
+    }
+
     .unused {
       color: @text-color;
     }
@@ -22,8 +26,12 @@
       color: @text-color-subtle;
     }
 
-    .used .command, .unused .command{
+    .used .command, .unused .command {
       .octicon(check);
+    }
+
+    .aborted .command {
+      .octicon(stop);
     }
 
     .unmatched .command {


### PR DESCRIPTION
### Description of the Change

<img width="1065" alt="screen shot 2017-10-11 at 4 29 56 pm" src="https://user-images.githubusercontent.com/1038121/31472128-a2dbaf20-aea1-11e7-94e0-81ec1f0b58d4.png">

Adds a new `aborted` type to the resolver display with the stop octicon so people can see when a keybinding has been selected because others have been aborted before it. This is in addition to the `used`, `unused` and `unmatched` types already present.

### Alternate Designs

None considered.

### Benefits

Gives people more information on why a key binding is selected.

### Possible Drawbacks

There is confusion around an aborted keybinding which allows other keybindings to be found and the `abort!` command which does not. This does nothing to alleviate this confusion.

### Applicable Issues

* atom/atom-keymap#227
