### PR TITLE
Dispose commands when deactivated

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,16 +1,20 @@
+const {CompositeDisposable} = require('atom')
+
 const KeyBindingResolverView = require('./keybinding-resolver-view')
 
 module.exports = {
   keybindingResolverView: null,
 
   activate (state = {}) {
+    this.disposables = new CompositeDisposable()
+
     const {attached} = state
     if (attached) this.getKeybindingResolverView().toggle()
-    atom.commands.add('atom-workspace', {
+    this.disposables.add(atom.commands.add('atom-workspace', {
       'key-binding-resolver:toggle': () => this.getKeybindingResolverView().toggle(),
       'core:cancel': () => this.getKeybindingResolverView().detach(),
       'core:close': () => this.getKeybindingResolverView().detach()
-    })
+    }))
   },
 
   getKeybindingResolverView () {
@@ -21,6 +25,7 @@ module.exports = {
   },
 
   deactivate () {
+    this.disposables.dispose()
     if (this.keybindingResolverView != null) {
       this.keybindingResolverView.destroy()
     }


### PR DESCRIPTION
Prevents commands from sticking around after the package is deactivated.