### PR TITLE
Docks!

### DIFF
--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -3,7 +3,7 @@
 
 import fs from 'fs-plus'
 import etch from 'etch'
-import {Disposable, CompositeDisposable} from 'atom'
+import {CompositeDisposable} from 'atom'
 import path from 'path'
 
 export default class KeyBindingResolverView {
@@ -13,33 +13,7 @@ export default class KeyBindingResolverView {
     this.unusedKeyBindings = []
     this.unmatchedKeyBindings = []
     this.partiallyMatchedBindings = []
-    etch.initialize(this)
-  }
-
-  serialize () {
-    return this.panel ? {attached: this.panel.isVisible()} : {attached: false}
-  }
-
-  destroy () {
-    this.detach()
-    return etch.destroy(this)
-  }
-
-  toggle () {
-    if (this.panel && this.panel.isVisible()) {
-      this.detach()
-    } else {
-      this.attach()
-    }
-  }
-
-  attach () {
     this.disposables = new CompositeDisposable()
-    this.panel = atom.workspace.addBottomPanel({item: this})
-    this.disposables.add(new Disposable(() => {
-      this.panel.destroy()
-      this.panel = null
-    }))
 
     this.disposables.add(atom.keymaps.onDidMatchBinding(({keystrokes, binding, keyboardEventTarget, eventType}) => {
       if (eventType === 'keyup' && binding == null) {
@@ -73,12 +47,44 @@ export default class KeyBindingResolverView {
 
       this.update({unusedKeyBindings, unmatchedKeyBindings, keystrokes})
     }))
+
+    etch.initialize(this)
+  }
+
+  getTitle () {
+    return 'Key Binding Resolver'
+  }
+
+  getIconName () {
+    return 'keyboard'
+  }
+
+  getDefaultLocation () {
+    return 'bottom'
+  }
+
+  getAllowedLocations () {
+    // TODO: Support left and right possibly
+    return ['bottom']
+  }
+
+  getURI () {
+    return 'atom://keybinding-resolver'
+  }
+
+  serialize () {
+    return {
+      deserializer: 'keybinding-resolver/KeyBindingResolverView'
+    }
+  }
+
+  destroy () {
+    this.detach()
+    return etch.destroy(this)
   }
 
   detach () {
-    if (this.disposables) {
-      this.disposables.dispose()
-    }
+    this.disposables.dispose()
   }
 
   update (props) {

--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -93,8 +93,8 @@ export default class KeyBindingResolverView {
   render () {
     return (
       <div className='key-binding-resolver'>
-        <div className='panel-heading padded'>{this.renderKeystrokes()}</div>
-        <div className='panel-body padded'>{this.renderKeyBindings()}</div>
+        <div className='panel-heading'>{this.renderKeystrokes()}</div>
+        <div className='panel-body'>{this.renderKeyBindings()}</div>
       </div>
     )
   }
@@ -102,9 +102,9 @@ export default class KeyBindingResolverView {
   renderKeystrokes () {
     if (this.keystrokes) {
       if (this.partiallyMatchedBindings.length > 0) {
-        return <span className='keystroke'>{this.keystrokes} (partial)</span>
+        return <span className='keystroke highlight-info'>{this.keystrokes} (partial)</span>
       } else {
-        return <span className='keystroke'>{this.keystrokes}</span>
+        return <span className='keystroke highlight-info'>{this.keystrokes}</span>
       }
     } else {
       return <span>Press any key</span>

--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -99,10 +99,7 @@ export default class KeyBindingResolverView {
   render () {
     return (
       <div className='key-binding-resolver'>
-        <div className='panel-heading padded'>
-          <span>Key Binding Resolver: </span>
-          {this.renderKeystrokes()}
-        </div>
+        <div className='panel-heading padded'>{this.renderKeystrokes()}</div>
         <div className='panel-body padded'>{this.renderKeyBindings()}</div>
       </div>
     )
@@ -116,7 +113,7 @@ export default class KeyBindingResolverView {
         return <span className='keystroke'>{this.keystrokes}</span>
       }
     } else {
-      return <span>Press any key: </span>
+      return <span>Press any key</span>
     }
   }
 

--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -72,12 +72,6 @@ export default class KeyBindingResolverView {
     return 'atom://keybinding-resolver'
   }
 
-  serialize () {
-    return {
-      deserializer: 'keybinding-resolver/KeyBindingResolverView'
-    }
-  }
-
   destroy () {
     this.detach()
     return etch.destroy(this)

--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -57,6 +57,12 @@ export default class KeyBindingResolverView {
     return 'atom://keybinding-resolver'
   }
 
+  serialize () {
+    return {
+      deserializer: 'keybinding-resolver/KeyBindingResolverView'
+    }
+  }
+
   destroy () {
     this.disposables.dispose()
     this.detach()

--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -13,39 +13,24 @@ export default class KeyBindingResolverView {
     this.unusedKeyBindings = []
     this.unmatchedKeyBindings = []
     this.partiallyMatchedBindings = []
+    this.attached = false
     this.disposables = new CompositeDisposable()
+    this.keybindingDisposables = new CompositeDisposable()
 
-    this.disposables.add(atom.keymaps.onDidMatchBinding(({keystrokes, binding, keyboardEventTarget, eventType}) => {
-      if (eventType === 'keyup' && binding == null) {
-        return
+    this.disposables.add(atom.workspace.getBottomDock().observeActivePaneItem(item => {
+      if (item === this) {
+        this.attach()
+      } else {
+        this.detach()
       }
-
-      const unusedKeyBindings = atom.keymaps
-        .findKeyBindings({keystrokes, target: keyboardEventTarget})
-        .filter((b) => b !== binding)
-
-      const unmatchedKeyBindings = atom.keymaps
-        .findKeyBindings({keystrokes})
-        .filter((b) => b !== binding && !unusedKeyBindings.includes(b))
-
-      this.update({usedKeyBinding: binding, unusedKeyBindings, unmatchedKeyBindings, keystrokes})
     }))
 
-    this.disposables.add(atom.keymaps.onDidPartiallyMatchBindings(({keystrokes, partiallyMatchedBindings}) => {
-      this.update({keystrokes, partiallyMatchedBindings})
-    }))
-
-    this.disposables.add(atom.keymaps.onDidFailToMatchBinding(({keystrokes, keyboardEventTarget, eventType}) => {
-      if (eventType === 'keyup') {
-        return
+    this.disposables.add(atom.workspace.getBottomDock().observeVisible(visible => {
+      if (visible) {
+        if (atom.workspace.getBottomDock().getActivePaneItem() === this) this.attach()
+      } else {
+        this.detach()
       }
-
-      const unusedKeyBindings = atom.keymaps.findKeyBindings({keystrokes, target: keyboardEventTarget})
-      const unmatchedKeyBindings = atom.keymaps
-        .findKeyBindings({keystrokes})
-        .filter((b) => !unusedKeyBindings.includes(b))
-
-      this.update({unusedKeyBindings, unmatchedKeyBindings, keystrokes})
     }))
 
     etch.initialize(this)
@@ -73,15 +58,62 @@ export default class KeyBindingResolverView {
   }
 
   destroy () {
+    this.disposables.dispose()
     this.detach()
     return etch.destroy(this)
   }
 
+  attach () {
+    if (this.attached) return
+
+    console.log('Attached')
+    this.attached = true
+    this.keybindingDisposables = new CompositeDisposable()
+    this.keybindingDisposables.add(atom.keymaps.onDidMatchBinding(({keystrokes, binding, keyboardEventTarget, eventType}) => {
+      if (eventType === 'keyup' && binding == null) {
+        return
+      }
+
+      const unusedKeyBindings = atom.keymaps
+        .findKeyBindings({keystrokes, target: keyboardEventTarget})
+        .filter((b) => b !== binding)
+
+      const unmatchedKeyBindings = atom.keymaps
+        .findKeyBindings({keystrokes})
+        .filter((b) => b !== binding && !unusedKeyBindings.includes(b))
+
+      this.update({usedKeyBinding: binding, unusedKeyBindings, unmatchedKeyBindings, keystrokes})
+    }))
+
+    this.keybindingDisposables.add(atom.keymaps.onDidPartiallyMatchBindings(({keystrokes, partiallyMatchedBindings}) => {
+      this.update({keystrokes, partiallyMatchedBindings})
+    }))
+
+    this.keybindingDisposables.add(atom.keymaps.onDidFailToMatchBinding(({keystrokes, keyboardEventTarget, eventType}) => {
+      if (eventType === 'keyup') {
+        return
+      }
+
+      const unusedKeyBindings = atom.keymaps.findKeyBindings({keystrokes, target: keyboardEventTarget})
+      const unmatchedKeyBindings = atom.keymaps
+        .findKeyBindings({keystrokes})
+        .filter((b) => !unusedKeyBindings.includes(b))
+
+      this.update({unusedKeyBindings, unmatchedKeyBindings, keystrokes})
+    }))
+  }
+
   detach () {
-    this.disposables.dispose()
+    if (!this.attached) return
+
+    console.log('Detached')
+    this.attached = false
+    this.keybindingDisposables.dispose()
+    this.keybindingDisposables = null
   }
 
   update (props) {
+    console.log('pew')
     this.keystrokes = props.keystrokes
     this.usedKeyBinding = props.usedKeyBinding
     this.unusedKeyBindings = props.unusedKeyBindings || []

--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -72,7 +72,6 @@ export default class KeyBindingResolverView {
   attach () {
     if (this.attached) return
 
-    console.log('Attached')
     this.attached = true
     this.keybindingDisposables = new CompositeDisposable()
     this.keybindingDisposables.add(atom.keymaps.onDidMatchBinding(({keystrokes, binding, keyboardEventTarget, eventType}) => {
@@ -112,7 +111,6 @@ export default class KeyBindingResolverView {
   detach () {
     if (!this.attached) return
 
-    console.log('Detached')
     this.attached = false
     this.keybindingDisposables.dispose()
     this.keybindingDisposables = null

--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -117,7 +117,6 @@ export default class KeyBindingResolverView {
   }
 
   update (props) {
-    console.log('pew')
     this.keystrokes = props.keystrokes
     this.usedKeyBinding = props.usedKeyBinding
     this.unusedKeyBindings = props.unusedKeyBindings || []

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,39 +2,44 @@ const {CompositeDisposable} = require('atom')
 
 const KeyBindingResolverView = require('./keybinding-resolver-view')
 
+const KEYBINDING_RESOLVER_URI = 'atom://keybinding-resolver'
+
 module.exports = {
-  keybindingResolverView: null,
+  activate () {
+    this.subscriptions = new CompositeDisposable()
 
-  activate (state = {}) {
-    this.disposables = new CompositeDisposable()
+    this.subscriptions.add(atom.workspace.addOpener(uri => {
+      if (uri === KEYBINDING_RESOLVER_URI) {
+        return new KeyBindingResolverView()
+      }
+    }))
 
-    const {attached} = state
-    if (attached) this.getKeybindingResolverView().toggle()
-    this.disposables.add(atom.commands.add('atom-workspace', {
-      'key-binding-resolver:toggle': () => this.getKeybindingResolverView().toggle(),
-      'core:cancel': () => this.getKeybindingResolverView().detach(),
-      'core:close': () => this.getKeybindingResolverView().detach()
+    this.subscriptions.add(atom.commands.add('atom-workspace', {
+      'key-binding-resolver:toggle': () => this.toggle()
     }))
   },
 
-  getKeybindingResolverView () {
-    if (this.keybindingResolverView == null) {
-      this.keybindingResolverView = new KeyBindingResolverView()
-    }
-    return this.keybindingResolverView
-  },
-
-  deactivate () {
-    this.disposables.dispose()
-    if (this.keybindingResolverView != null) {
-      this.keybindingResolverView.destroy()
+  async deactivate () {
+    this.subscriptions.dispose()
+    let pane = atom.workspace.paneForURI(KEYBINDING_RESOLVER_URI)
+    while (pane) {
+      await pane.destroyItem(pane.itemForURI(KEYBINDING_RESOLVER_URI))
+      pane = atom.workspace.paneForURI(KEYBINDING_RESOLVER_URI)
     }
   },
 
-  serialize () {
-    if (this.keybindingResolverView != null) {
-      return this.keybindingResolverView.serialize()
+  toggle () {
+    const pane = atom.workspace.paneForURI(KEYBINDING_RESOLVER_URI)
+    if (pane) {
+      atom.workspace.hide(KEYBINDING_RESOLVER_URI)
+      // Also destroy the view so that we don't keep capturing keybinding events
+      pane.destroyItem(pane.itemForURI(KEYBINDING_RESOLVER_URI))
+    } else {
+      atom.workspace.open(KEYBINDING_RESOLVER_URI)
     }
-    return undefined
+  },
+
+  deserializeKeyBindingResolverView (serialized) {
+    return new KeyBindingResolverView()
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -30,7 +30,7 @@ module.exports = {
 
   toggle () {
     const pane = atom.workspace.paneForURI(KEYBINDING_RESOLVER_URI)
-    if (pane) {
+    if (pane && atom.workspace.getBottomDock().isVisible()) {
       atom.workspace.hide(KEYBINDING_RESOLVER_URI)
       // Also destroy the view so that we don't keep capturing keybinding events
       pane.destroyItem(pane.itemForURI(KEYBINDING_RESOLVER_URI))

--- a/lib/main.js
+++ b/lib/main.js
@@ -37,9 +37,5 @@ module.exports = {
     } else {
       atom.workspace.open(KEYBINDING_RESOLVER_URI)
     }
-  },
-
-  deserializeKeyBindingResolverView (serialized) {
-    return new KeyBindingResolverView()
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -29,6 +29,8 @@ module.exports = {
 
   toggle () {
     const pane = atom.workspace.paneForURI(KEYBINDING_RESOLVER_URI)
+    // FIXME: This should check if the pane itself is visible, not the bottom dock.
+    // This will allow us to support more dock locations.
     if (pane && atom.workspace.getBottomDock().isVisible()) {
       atom.workspace.hide(KEYBINDING_RESOLVER_URI)
       // Also destroy the view so that we don't keep capturing keybinding events

--- a/lib/main.js
+++ b/lib/main.js
@@ -19,12 +19,11 @@ module.exports = {
     }))
   },
 
-  async deactivate () {
+  deactivate () {
     this.subscriptions.dispose()
-    let pane = atom.workspace.paneForURI(KEYBINDING_RESOLVER_URI)
-    while (pane) {
-      await pane.destroyItem(pane.itemForURI(KEYBINDING_RESOLVER_URI))
-      pane = atom.workspace.paneForURI(KEYBINDING_RESOLVER_URI)
+    const pane = atom.workspace.paneForURI(KEYBINDING_RESOLVER_URI)
+    if (pane) {
+      pane.destroyItem(pane.itemForURI(KEYBINDING_RESOLVER_URI))
     }
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -21,22 +21,9 @@ module.exports = {
 
   deactivate () {
     this.subscriptions.dispose()
-    const pane = atom.workspace.paneForURI(KEYBINDING_RESOLVER_URI)
-    if (pane) {
-      pane.destroyItem(pane.itemForURI(KEYBINDING_RESOLVER_URI))
-    }
   },
 
   toggle () {
-    const pane = atom.workspace.paneForURI(KEYBINDING_RESOLVER_URI)
-    // FIXME: This should check if the pane itself is visible, not the bottom dock.
-    // This will allow us to support more dock locations.
-    if (pane && atom.workspace.getBottomDock().isVisible()) {
-      atom.workspace.hide(KEYBINDING_RESOLVER_URI)
-      // Also destroy the view so that we don't keep capturing keybinding events
-      pane.destroyItem(pane.itemForURI(KEYBINDING_RESOLVER_URI))
-    } else {
-      atom.workspace.open(KEYBINDING_RESOLVER_URI)
-    }
+    atom.workspace.toggle(KEYBINDING_RESOLVER_URI)
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -25,5 +25,9 @@ module.exports = {
 
   toggle () {
     atom.workspace.toggle(KEYBINDING_RESOLVER_URI)
+  },
+
+  deserializeKeyBindingResolverView (serialized) {
+    return new KeyBindingResolverView()
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "https://github.com/atom/keybinding-resolver",
   "engines": {
-    "atom": ">0.79.0"
+    "atom": ">=1.17.0"
   },
   "dependencies": {
     "etch": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
   "engines": {
     "atom": ">0.79.0"
   },
-  "deserializers": {
-    "keybinding-resolver/KeyBindingResolverView": "deserializeKeyBindingResolverView"
-  },
   "dependencies": {
     "etch": "0.9.0",
     "fs-plus": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "engines": {
     "atom": ">0.79.0"
   },
+  "deserializers": {
+    "keybinding-resolver/KeyBindingResolverView": "deserializeKeyBindingResolverView"
+  },
   "dependencies": {
     "etch": "0.9.0",
     "fs-plus": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "engines": {
     "atom": ">=1.17.0"
   },
+  "deserializers": {
+    "keybinding-resolver/KeyBindingResolverView": "deserializeKeyBindingResolverView"
+  },
   "dependencies": {
     "etch": "0.9.0",
     "fs-plus": "^3.0.0",

--- a/spec/keybinding-resolver-view-spec.js
+++ b/spec/keybinding-resolver-view-spec.js
@@ -37,6 +37,28 @@ describe('KeyBindingResolverView', () => {
         expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
       })
     })
+
+    it('focuses the view if it is not visible instead of destroying it', () => {
+      const visibilitySpy = jasmine.createSpy('onDidChangeVisible')
+      atom.workspace.getBottomDock().onDidChangeVisible(visibilitySpy)
+
+      expect(bottomDockElement.querySelector('.key-binding-resolver')).not.toExist()
+
+      atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
+      waitsFor(() => visibilitySpy.callCount === 1)
+      runs(() => {
+        expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
+
+        atom.workspace.getBottomDock().hide()
+        atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
+      })
+
+      waitsFor(() => visibilitySpy.callCount === 3) // the second count happened when the dock was toggled
+      runs(() => {
+        expect(atom.workspace.getBottomDock().isVisible()).toBe(true)
+        expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
+      })
+    })
   })
 
   describe('when a keydown event occurs', () => {

--- a/spec/keybinding-resolver-view-spec.js
+++ b/spec/keybinding-resolver-view-spec.js
@@ -27,15 +27,12 @@ describe('KeyBindingResolverView', () => {
 
       waitsFor(() => visibilitySpy.callCount === 2)
       runs(() => {
-        expect(bottomDockElement.querySelector('.key-binding-resolver')).not.toExist()
+        expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
 
         atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
       })
 
       waitsFor(() => visibilitySpy.callCount === 3)
-      runs(() => {
-        expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
-      })
     })
 
     it('focuses the view if it is not visible instead of destroying it', () => {

--- a/spec/keybinding-resolver-view-spec.js
+++ b/spec/keybinding-resolver-view-spec.js
@@ -76,7 +76,7 @@ describe('KeyBindingResolverView', () => {
         }
       })
 
-      atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
+      await atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
 
       document.dispatchEvent(atom.keymaps.constructor.buildKeydownEvent('x', {target: bottomDockElement}))
       await etch.getScheduler().getNextUpdatePromise()
@@ -117,7 +117,7 @@ describe('KeyBindingResolverView', () => {
         }
       })
 
-      atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
+      await atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
 
       // Not partial because it dispatches the command for `x` immediately due to only having keyup events in remainder of partial match
       document.dispatchEvent(atom.keymaps.constructor.buildKeydownEvent('x', {target: bottomDockElement}))

--- a/spec/keybinding-resolver-view-spec.js
+++ b/spec/keybinding-resolver-view-spec.js
@@ -11,50 +11,36 @@ describe('KeyBindingResolverView', () => {
   })
 
   describe('when the key-binding-resolver:toggle event is triggered', () => {
-    it('creates and then destroys the view', () => {
-      const visibilitySpy = jasmine.createSpy('onDidChangeVisible')
-      atom.workspace.getBottomDock().onDidChangeVisible(visibilitySpy)
-
+    it('toggles the view', async () => {
+      expect(atom.workspace.getBottomDock().isVisible()).toBe(false)
       expect(bottomDockElement.querySelector('.key-binding-resolver')).not.toExist()
 
-      atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
-      waitsFor(() => visibilitySpy.callCount === 1)
-      runs(() => {
-        expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
+      await atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
+      expect(atom.workspace.getBottomDock().isVisible()).toBe(true)
+      expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
 
-        atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
-      })
+      await atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
+      expect(atom.workspace.getBottomDock().isVisible()).toBe(false)
+      expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
 
-      waitsFor(() => visibilitySpy.callCount === 2)
-      runs(() => {
-        expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
-
-        atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
-      })
-
-      waitsFor(() => visibilitySpy.callCount === 3)
+      await atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
+      expect(atom.workspace.getBottomDock().isVisible()).toBe(true)
+      expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
     })
 
-    it('focuses the view if it is not visible instead of destroying it', () => {
-      const visibilitySpy = jasmine.createSpy('onDidChangeVisible')
-      atom.workspace.getBottomDock().onDidChangeVisible(visibilitySpy)
-
+    it('focuses the view if it is not visible instead of destroying it', async () => {
+      expect(atom.workspace.getBottomDock().isVisible()).toBe(false)
       expect(bottomDockElement.querySelector('.key-binding-resolver')).not.toExist()
 
-      atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
-      waitsFor(() => visibilitySpy.callCount === 1)
-      runs(() => {
-        expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
+      await atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
+      expect(atom.workspace.getBottomDock().isVisible()).toBe(true)
+      expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
 
-        atom.workspace.getBottomDock().hide()
-        atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
-      })
+      atom.workspace.getBottomDock().hide()
+      await atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
 
-      waitsFor(() => visibilitySpy.callCount === 3) // the second count happened when the dock was toggled
-      runs(() => {
-        expect(atom.workspace.getBottomDock().isVisible()).toBe(true)
-        expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
-      })
+      expect(atom.workspace.getBottomDock().isVisible()).toBe(true)
+      expect(bottomDockElement.querySelector('.key-binding-resolver')).toExist()
     })
   })
 

--- a/spec/keybinding-resolver-view-spec.js
+++ b/spec/keybinding-resolver-view-spec.js
@@ -44,6 +44,46 @@ describe('KeyBindingResolverView', () => {
     })
   })
 
+  describe('capturing keybinding events', () => {
+    it('captures events when the keybinding resolver is visible', async () => {
+      await atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
+      const keybindingResolverView = atom.workspace.getBottomDock().getActivePaneItem()
+      expect(keybindingResolverView.keybindingDisposables).not.toBe(null)
+
+      document.dispatchEvent(atom.keymaps.constructor.buildKeydownEvent('x', {target: bottomDockElement}))
+      await etch.getScheduler().getNextUpdatePromise()
+      expect(bottomDockElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe('x')
+    })
+
+    it('does not capture events when the keybinding resolver is not the active pane item', async () => {
+      await atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
+      const keybindingResolverView = atom.workspace.getBottomDock().getActivePaneItem()
+      expect(keybindingResolverView.keybindingDisposables).not.toBe(null)
+
+      atom.workspace.getBottomDock().getActivePane().splitRight()
+      expect(keybindingResolverView.keybindingDisposables).toBe(null)
+
+      atom.workspace.getBottomDock().getActivePane().destroy()
+      document.dispatchEvent(atom.keymaps.constructor.buildKeydownEvent('x', {target: bottomDockElement}))
+      await etch.getScheduler().getNextUpdatePromise()
+      expect(bottomDockElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe('x')
+    })
+
+    it('does not capture events when the dock the keybinding resolver is in is not visible', async () => {
+      await atom.commands.dispatch(workspaceElement, 'key-binding-resolver:toggle')
+      const keybindingResolverView = atom.workspace.getBottomDock().getActivePaneItem()
+      expect(keybindingResolverView.keybindingDisposables).not.toBe(null)
+
+      atom.workspace.getBottomDock().hide()
+      expect(keybindingResolverView.keybindingDisposables).toBe(null)
+
+      atom.workspace.getBottomDock().show()
+      document.dispatchEvent(atom.keymaps.constructor.buildKeydownEvent('x', {target: bottomDockElement}))
+      await etch.getScheduler().getNextUpdatePromise()
+      expect(bottomDockElement.querySelector('.key-binding-resolver .keystroke').textContent).toBe('x')
+    })
+  })
+
   describe('when a keydown event occurs', () => {
     it('displays all commands for the keydown event but does not clear for the keyup when there is no keyup binding', async () => {
       atom.keymaps.add('name', {

--- a/styles/keybinding-resolver.less
+++ b/styles/keybinding-resolver.less
@@ -2,11 +2,15 @@
 @import "octicon-mixins";
 
 .key-binding-resolver {
-  -webkit-flex: 0.25;
   overflow: auto;
 
   .keystroke {
     margin-right: 1em;
+  }
+
+  .panel-heading {
+    position: sticky;
+    top: 0;
   }
 
   table {
@@ -22,7 +26,7 @@
       color: @text-color-subtle;
     }
 
-    .used .command, .unused .command{
+    .used .command, .unused .command {
       .octicon(check);
     }
 

--- a/styles/keybinding-resolver.less
+++ b/styles/keybinding-resolver.less
@@ -4,16 +4,22 @@
 .key-binding-resolver {
   overflow: auto;
 
-  .keystroke {
-    margin-right: 1em;
-  }
-
   .panel-heading {
     position: sticky;
     top: 0;
+    z-index: 1;
+  }
+
+  .panel-body {
+    padding: 0 @component-padding;
   }
 
   table {
+
+    tr:not(:last-child) {
+      border-bottom: 1px solid @base-border-color;
+    }
+
     .used {
       color: @text-color-success;
     }
@@ -26,7 +32,17 @@
       color: @text-color-subtle;
     }
 
-    .used .command, .unused .command {
+    // move icon so text is aligned when wrapped
+    .command {
+      padding-left: @component-icon-size;
+      &:before {
+        position: absolute;
+        margin-left: -@component-icon-size;
+      }
+    }
+
+    .used .command,
+    .unused .command {
       .octicon(check);
     }
 
@@ -34,8 +50,11 @@
       .octicon(x);
     }
 
-    .command, .selector, .source {
+    .command,
+    .selector,
+    .source {
       min-width: 10em;
+      word-break: break-word; // wrap long path names
     }
 
     .source {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Converts the Keybinding Resolver into a Dock.  This fixes some usability issues with the resolver, such as:
* Variable height causing the keybinding resolver to obscure the entire workspace when a large amount of keybindings are present.  Since it's now constrained in a dock, the keybindings will scroll instead.
* Lack of a close button
* Inability to view whatever was bound to `core:cancel` (due to it closing the resolver first)

And adds a nice styling touch to make the header sticky.

### Alternate Designs

None.

### Benefits

See above.

### Possible Drawbacks

I don't foresee any.  This should strictly be an upgrade from the existing panel, though I may be missing something.  One small thing is that after using the resolver, you might be inclined to close the dock instead of the keybinding resolver.  In that case the resolver will still be active and continue to track and display keybindings, resulting in a small performance penalty.

### Applicable Issues

Closes #17
Fixes #24
Closes #27
Supersedes and closes #53

/cc @Ben3eeE @UziTech

Most of the boilerplate code was copied from the active-editor-info example package.  I don't want to needlessly ping someone, but thanks a lot `@matthewwithanm` for writing that :).  Helped me a lot!