### PR TITLE
config flag for making panel persistent

### DIFF
--- a/keymaps/keybinding-resolver.cson
+++ b/keymaps/keybinding-resolver.cson
@@ -1,8 +1,8 @@
 '.platform-darwin':
-  'cmd-.': 'key-binding-resolver:toggle'
+  'cmd-.': 'keybinding-resolver:toggle'
 
 '.platform-win32':
-  'ctrl-.': 'key-binding-resolver:toggle'
+  'ctrl-.': 'keybinding-resolver:toggle'
 
 '.platform-linux':
-  'ctrl-.': 'key-binding-resolver:toggle'
+  'ctrl-.': 'keybinding-resolver:toggle'

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,11 +16,12 @@ module.exports = {
       'keybinding-resolver:toggle': () => this.getKeybindingResolverView().toggle()
     }))
 
-    if (!atom.config.get('keybinding-resolver.persistentPanel'))
+    if (!atom.config.get('keybinding-resolver.persistentPanel')) {
       this.disposables.add(atom.commands.add('atom-workspace', {
         'core:cancel': () => this.getKeybindingResolverView().detach(),
         'core:close': () => this.getKeybindingResolverView().detach()
       }))
+    }
   },
 
   getKeybindingResolverView () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,11 +9,11 @@ module.exports = {
     this.disposables = new CompositeDisposable()
 
     const {attached} = state
-    if (attached)
+    if (attached) {
       this.getKeybindingResolverView().toggle()
-
+    }
     this.disposables.add(atom.commands.add('atom-workspace', {
-      'keybinding-resolver:toggle': () => this.getKeybindingResolverView().toggle(),
+      'keybinding-resolver:toggle': () => this.getKeybindingResolverView().toggle()
     }))
 
     if (!atom.config.get('keybinding-resolver.persistentPanel'))
@@ -44,11 +44,11 @@ module.exports = {
     return undefined
   },
 
-  config : {
-    persistentPanel : {
-      type : 'boolean',
-      default : false,
-      title : 'Panel stays open, responds only to "toggle", not cancel or close'
+  config: {
+    persistentPanel: {
+      type: 'boolean',
+      default: false,
+      title: 'Panel stays open, responds only to "toggle", not cancel or close'
     }
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,12 +9,18 @@ module.exports = {
     this.disposables = new CompositeDisposable()
 
     const {attached} = state
-    if (attached) this.getKeybindingResolverView().toggle()
+    if (attached)
+      this.getKeybindingResolverView().toggle()
+
     this.disposables.add(atom.commands.add('atom-workspace', {
-      'key-binding-resolver:toggle': () => this.getKeybindingResolverView().toggle(),
-      'core:cancel': () => this.getKeybindingResolverView().detach(),
-      'core:close': () => this.getKeybindingResolverView().detach()
+      'keybinding-resolver:toggle': () => this.getKeybindingResolverView().toggle(),
     }))
+
+    if (!atom.config.get('keybinding-resolver.persistentPanel'))
+      this.disposables.add(atom.commands.add('atom-workspace', {
+        'core:cancel': () => this.getKeybindingResolverView().detach(),
+        'core:close': () => this.getKeybindingResolverView().detach()
+      }))
   },
 
   getKeybindingResolverView () {
@@ -36,5 +42,13 @@ module.exports = {
       return this.keybindingResolverView.serialize()
     }
     return undefined
+  },
+
+  config : {
+    persistentPanel : {
+      type : 'boolean',
+      default : false,
+      title : 'Panel stays open, responds only to "toggle", not cancel or close'
+    }
   }
 }


### PR DESCRIPTION
### Description of the Change

add config flag for holding panel open.   make binding name consistent with repository name.
`
key-binding -> keybinding
`
