### PR TITLE
Added a clippy to the list to copyKeybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,7 @@ Shows what commands a keybinding resolves to.
 
 You can open and close the resolver using <kbd>cmd-.</kbd>.
 
-![](https://f.cloud.github.com/assets/671378/2241702/5dd5a102-9cde-11e3-9e3f-1d999930492f.png)
+Please note the clipboard icon which can be selected to copy the given keybinding
+directive so that you can easily paste it into your keymap files.
+
+![](https://user-images.githubusercontent.com/4137660/44482876-8de73a80-a617-11e8-8bd5-24023c96b39e.png)

--- a/lib/keybinding-resolver-view.js
+++ b/lib/keybinding-resolver-view.js
@@ -121,6 +121,7 @@ export default class KeyBindingResolverView {
           <tbody>
             {this.partiallyMatchedBindings.map((binding) => (
               <tr className='unused'>
+                <td className='copy' onclick={() => this.copyKeybinding(binding)}><span className='icon icon-clippy' /></td>
                 <td className='command'>{binding.command}</td>
                 <td className='keystrokes'>{binding.keystrokes}</td>
                 <td className='selector'>{binding.selector}</td>
@@ -135,6 +136,7 @@ export default class KeyBindingResolverView {
       if (this.usedKeyBinding) {
         usedKeyBinding = (
           <tr className='used'>
+            <td className='copy' onclick={() => this.copyKeybinding(this.usedKeyBinding)}><span className='icon icon-clippy' /></td>
             <td className='command'>{this.usedKeyBinding.command}</td>
             <td className='selector'>{this.usedKeyBinding.selector}</td>
             <td className='source' onclick={() => this.openKeybindingFile(this.usedKeyBinding.source)}>{this.usedKeyBinding.source}</td>
@@ -147,6 +149,7 @@ export default class KeyBindingResolverView {
             {usedKeyBinding}
             {this.unusedKeyBindings.map((binding) => (
               <tr className='unused'>
+                <td className='copy' onclick={() => this.copyKeybinding(binding)}><span className='icon icon-clippy' /></td>
                 <td className='command'>{binding.command}</td>
                 <td className='selector'>{binding.selector}</td>
                 <td className='source' onclick={() => this.openKeybindingFile(binding.source)}>{binding.source}</td>
@@ -154,6 +157,7 @@ export default class KeyBindingResolverView {
             ))}
             {this.unmatchedKeyBindings.map((binding) => (
               <tr className='unmatched'>
+                <td className='copy' onclick={() => this.copyKeybinding(binding)}><span className='icon icon-clippy' /></td>
                 <td className='command'>{binding.command}</td>
                 <td className='selector'>{binding.selector}</td>
                 <td className='source' onclick={() => this.openKeybindingFile(binding.source)}>{binding.source}</td>
@@ -205,5 +209,26 @@ export default class KeyBindingResolverView {
     }
 
     atom.workspace.open(keymapPath)
+  }
+
+  copyKeybinding (binding) {
+    let content
+    const keymapExtension = path.extname(atom.keymaps.getUserKeymapPath())
+    let escapedKeystrokes = binding.keystrokes.replace(/\\/g, '\\\\') // Escape backslashes
+    if (keymapExtension === '.cson') {
+      content = `\
+'${binding.selector}':
+  '${escapedKeystrokes}': '${binding.command}'
+`
+    } else {
+      content = `\
+"${binding.selector}": {
+  "${escapedKeystrokes}": "${binding.command}"
+}
+`
+    }
+
+    atom.notifications.addInfo('Keybinding Copied')
+    return atom.clipboard.write(content)
   }
 }


### PR DESCRIPTION
Similar to the keybindings list in settings-view, the clippy copies the binding
for easier editing / keymap customizations

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This is a simple change to add a 'clippy' icon to allow the keybindings to be copied.  This is the same code from the settings-view on keybindings.

*Edit by @rsese to add the [screenshots](https://github.com/atom/keybinding-resolver/pull/62#issuecomment-415133553)*

![keybinding-screenshot](https://user-images.githubusercontent.com/4137660/44482876-8de73a80-a617-11e8-8bd5-24023c96b39e.png)
![keybinding-screenshot-atom-dark](https://user-images.githubusercontent.com/4137660/44482906-a3f4fb00-a617-11e8-9559-4525dc624452.png)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

This makes it so much easier to customize your keybindings by finding where the conflicts exist and overriding them in your local keymap.

### Possible Drawbacks

People spend all day customizing their keymaps.

### Applicable Issues

Looks like can close #34 which was written some time ago with similar intent, but this ain't coffee anymore ;)

Closes #30 
Closes #34