### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -665,9 +665,9 @@
       "dev": true
     },
     "etch": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/etch/-/etch-0.14.0.tgz",
-      "integrity": "sha512-puqbFxz7lSm+YK6Q+bvRkNndRv6PRvGscSEhcFjmtL4nX/Az5rRCNPvK3aVTde85c/L5X0vI5kqfnpYddRalJQ=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/etch/-/etch-0.9.0.tgz",
+      "integrity": "sha1-CSJpiPLO4GkL3yCMyyXkFNXfrV8="
     },
     "event-emitter": {
       "version": "0.3.5",


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

When cloning the repo and running `npm install` (with npm@6.4.1), package-lock.json changes which version of etch is resolved. package.json states 0.9.0, whereas package-lock.json was resolving 0.14.0. I think this is the correct change (lock to etch@0.9.0) by looking at commit history.

If this isn't the correct change or there is something else I can help out with here, please let me know.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

N/A

### Benefits

<!-- What benefits will be realized by the code change? -->

This could help ensure the desired version of etch is installed when running `npm install`.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

N/A

### Applicable Issues

<!-- Enter any applicable Issues here -->

N/A
