### PR TITLE
Fix failing specs

### DIFF
--- a/spec/keybinding-resolver-view-spec.js
+++ b/spec/keybinding-resolver-view-spec.js
@@ -8,6 +8,7 @@ describe('KeyBindingResolverView', () => {
     workspaceElement = atom.views.getView(atom.workspace)
     bottomDockElement = atom.views.getView(atom.workspace.getBottomDock())
     await atom.packages.activatePackage('keybinding-resolver')
+    jasmine.attachToDOM(workspaceElement);
   })
 
   describe('when the key-binding-resolver:toggle event is triggered', () => {


### PR DESCRIPTION
Due to the recent Atom update. Atom is now using customElements. We now
need to attach the worksaceElement to the DOM to get the specs passing.
